### PR TITLE
Rolling file by date writes to original file

### DIFF
--- a/writers_rollingfilewriter_test.go
+++ b/writers_rollingfilewriter_test.go
@@ -61,7 +61,7 @@ func createRollingDatefileWriterTestCase(
 	return &fileWriterTestCase{files, fileName, rollingTypeTime, 0, 0, datePattern, writeCount, resFiles, nameMode, archiveType, archiveExploded, archivePath}
 }
 
-func TestShouldArchiveWithTar(t*testing.T) {
+func TestShouldArchiveWithTar(t *testing.T) {
 	compressionType := compressionTypes[rollingArchiveGzip]
 
 	archiveName := compressionType.rollingArchiveTypeName("log", false)


### PR DESCRIPTION
This adds a .seelog_rolling_tracker to track the timestamp of the last log roll.
